### PR TITLE
[chore] import order 설정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,22 @@
 module.exports = {
   extends: "expo",
   ignorePatterns: ["/dist/*"],
+  plugins: ["simple-import-sort"],
   rules: {
     "import/namespace": ["error", { allowComputed: true }],
+    "simple-import-sort/imports": [
+      "error",
+      {
+        groups: [
+          ["^\\u0000"],
+          ["^expo"],
+          ["^react"],
+          ["^@"],
+          ["^[a-z]"],
+          ["^~"],
+          ["^\\./", "^\\.\\./"],
+        ],
+      },
+    ],
   },
 };

--- a/app/(tabs)/(event)/_layout.tsx
+++ b/app/(tabs)/(event)/_layout.tsx
@@ -1,5 +1,6 @@
-import MainHeader from "@/components/common/header/main-header";
 import { Stack } from "expo-router";
+
+import MainHeader from "@/components/common/header/main-header";
 
 export default function EventLayout() {
   return (

--- a/app/(tabs)/(event)/index.tsx
+++ b/app/(tabs)/(event)/index.tsx
@@ -1,10 +1,11 @@
+import { StyleSheet } from "react-native";
+
 import Button from "@/components/common/button";
+import Card from "@/components/common/card";
 import Container from "@/components/common/container";
 import Flex from "@/components/common/flex";
 import Icon from "@/components/common/icon";
 import Text from "@/components/common/text";
-import { StyleSheet } from "react-native";
-import Card from "@/components/common/card";
 
 const eventList = [
   {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,7 @@
+import { Tabs } from "expo-router";
+
 import Icon from "@/components/common/icon";
 import { colors, ColorValueType } from "@/constants/color";
-import { Tabs } from "expo-router";
 
 interface IconProps {
   fill: ColorValueType;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,7 +2,9 @@ import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
+
 import { useEffect } from "react";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 SplashScreen.preventAutoHideAsync();

--- a/components/common/button/text-button.tsx
+++ b/components/common/button/text-button.tsx
@@ -1,7 +1,10 @@
 import { StyleSheet, TouchableOpacityProps } from "react-native";
-import Button from ".";
-import Text from "../text";
+
 import { colors } from "@/constants/color";
+
+import Text from "../text";
+
+import Button from ".";
 
 interface TextButtonProps extends TouchableOpacityProps {
   children: string;

--- a/components/common/card/index.tsx
+++ b/components/common/card/index.tsx
@@ -1,9 +1,12 @@
 import { Image } from "expo-image";
+
+import { Dimensions, StyleSheet } from "react-native";
+
+import { colors } from "@/constants/color";
+
 import Button from "../button";
 import Flex from "../flex";
 import Text from "../text";
-import { Dimensions, StyleSheet } from "react-native";
-import { colors } from "@/constants/color";
 
 const { width } = Dimensions.get("screen");
 

--- a/components/common/container/index.tsx
+++ b/components/common/container/index.tsx
@@ -1,5 +1,6 @@
-import { colors } from "@/constants/color";
 import { ScrollView, ScrollViewProps, StyleSheet, View, ViewProps } from "react-native";
+
+import { colors } from "@/constants/color";
 
 type ContainerProps<T extends "View" | "ScrollView"> = {
   as: T;

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -1,4 +1,5 @@
 import { SafeAreaView, StyleSheet, View } from "react-native";
+
 import { colors } from "@/constants/color";
 
 interface HeaderProps {

--- a/components/common/header/main-header.tsx
+++ b/components/common/header/main-header.tsx
@@ -1,10 +1,14 @@
+import { Link } from "expo-router";
+
 import { StyleSheet } from "react-native";
-import Header from ".";
+
+import { colors } from "@/constants/color";
+
+import Flex from "../flex";
 import Icon from "../icon";
 import Text from "../text";
-import { colors } from "@/constants/color";
-import { Link } from "expo-router";
-import Flex from "../flex";
+
+import Header from ".";
 
 interface MainHeaderProps {
   title: string;

--- a/components/common/icon/index.tsx
+++ b/components/common/icon/index.tsx
@@ -1,5 +1,6 @@
-import { colors, ColorValueType } from "@/constants/color";
 import Svg, { Circle, Path } from "react-native-svg";
+
+import { colors, ColorValueType } from "@/constants/color";
 
 interface IconProps {
   size?: number;

--- a/components/common/input/index.tsx
+++ b/components/common/input/index.tsx
@@ -1,6 +1,8 @@
 import { StyleSheet, TextInput, TextInputProps } from "react-native";
-import Flex from "../flex";
+
 import { colors } from "@/constants/color";
+
+import Flex from "../flex";
 
 interface InputProps extends TextInputProps {
   type?: "fill" | "outline";

--- a/components/common/text/index.tsx
+++ b/components/common/text/index.tsx
@@ -1,5 +1,6 @@
+import { StyleSheet, Text as DefaultText, TextProps as DefaultTextProps } from "react-native";
+
 import { colors } from "@/constants/color";
-import { Text as DefaultText, TextProps as DefaultTextProps, StyleSheet } from "react-native";
 
 interface TextProps extends DefaultTextProps {
   size?: "sm" | "md" | "lg" | "xl";

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@types/react": "~18.3.12",
         "@types/react-test-renderer": "^18.3.0",
         "eslint-config-expo": "~8.0.1",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "jest": "^29.2.1",
         "jest-expo": "~52.0.2",
         "prettier": "^3.4.2",
@@ -8144,6 +8145,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
-    "lint": "expo lint",
+    "lint": "npx eslint . --fix",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "jest": {
@@ -20,10 +20,12 @@
     "@react-navigation/native": "^7.0.0",
     "@tanstack/react-query": "^5.62.8",
     "expo": "~52.0.20",
+    "expo-asset": "~11.0.1",
     "expo-blur": "~14.0.1",
     "expo-constants": "~17.0.3",
     "expo-font": "~13.0.2",
     "expo-haptics": "~14.0.0",
+    "expo-image": "~2.0.3",
     "expo-linking": "~7.0.3",
     "expo-router": "~4.0.14",
     "expo-splash-screen": "~0.29.18",
@@ -40,9 +42,7 @@
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5",
-    "expo-asset": "~11.0.1",
-    "expo-image": "~2.0.3"
+    "react-native-webview": "13.12.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -50,6 +50,7 @@
     "@types/react": "~18.3.12",
     "@types/react-test-renderer": "^18.3.0",
     "eslint-config-expo": "~8.0.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^29.2.1",
     "jest-expo": "~52.0.2",
     "prettier": "^3.4.2",


### PR DESCRIPTION
## 설명

<!--
해당 Pull Request에 대한 설명을 작성합니다.

ex)
백엔드와 소셜 로그인을 연동하는 작업을 진행했습니다.
 -->

이전 작업물에서 import가 섞여있어 불편한 경험이 있었습니다. 이를 해결하기 위해 import order를 할 수 있도록 eslint 설정을 진행하였습니다.

import 순서는 다음을 따릅니다.

- Side effect imports. ex) import "./setup";
- Start with "expo". ex) import { useFonts } from "expo-font";
- Start with "react". ex) import { useEffect } from "react";
- Start with "@". ex) import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
- Start with "lower case". ex) import lodash from "lodash";
- Using alias. ex) import Text from "@/components/common/text";
- Relative imports. ex) import Text from "../text";

## 작업내용

<!--
해당 Pull Request에서 진행했던 내용들을 작성합니다.

ex)
- [x] 카카오 로그인
- [x] 구글 로그인
 -->

- [x] simple-import-sort 적용

## 요청(선택)

<!--
리뷰어가 확인해주어야 하는 부분에 대해 작성합니다.

ex)
- 카카오 로그인 정상 작동하는지 확인 후 코멘트 부탁드립니다.
 -->

## 스크린샷(선택)

<!--
구현한 내용에 대한 스크린샷을 첨부합니다.
 -->

### 예시
![스크린샷 2024-12-22 오전 2 13 19](https://github.com/user-attachments/assets/c373faf1-31e3-4d98-9f3e-9e307b86727c)

## 연관 이슈

<!--
진행했던 이슈의 번호를 입력합니다.

ex)
resolved #1
-->

resolved #8 
